### PR TITLE
Install make

### DIFF
--- a/lib/itamae/plugin/recipe/tmux/dependency.rb
+++ b/lib/itamae/plugin/recipe/tmux/dependency.rb
@@ -1,2 +1,3 @@
 package "wget"
 package "gcc"
+package "make"


### PR DESCRIPTION
make is not installed debian8

+ bundle exec rake itamae:debian8
bundle exec itamae ssh --host=debian8 --vagrant --node-yaml=recipes/node.yml recipes/install.rb
 INFO : Starting Itamae...
 INFO : Loading node data from /pipeline/build/recipes/node.yml...
 INFO : Recipe: /pipeline/build/recipes/install.rb
 INFO :   Recipe: /pipeline/build/lib/itamae/plugin/recipe/tmux/default.rb
 INFO :     Recipe: /pipeline/build/lib/itamae/plugin/recipe/tmux/dependency.rb
 INFO :       package[gcc] installed will change from 'false' to 'true'
 INFO :     Recipe: /pipeline/build/lib/itamae/plugin/recipe/tmux/libevent.rb
 INFO :       execute[wget https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz] executed will change from 'false' to 'true'
 INFO :       execute[tar zxf libevent-2.0.22-stable.tar.gz] executed will change from 'false' to 'true'
 INFO :       execute[./configure --prefix=/usr/local] executed will change from 'false' to 'true'
 INFO :       execute[make] executed will change from 'false' to 'true'
ERROR :         stdout | /bin/sh: 1: make: not found
ERROR :         Command `cd /usr/local/src/libevent-2.0.22-stable && make` failed. (exit status: 127)
ERROR :       execute[make] Failed.

(cherry picked from commit 66c69ea399f7aa82be1c81c57fbcf902f0a68623)